### PR TITLE
fix: support `acornOptions.onComment` and `acornOptions.onToken`

### DIFF
--- a/packages/micromark-util-events-to-acorn/dev/index.js
+++ b/packages/micromark-util-events-to-acorn/dev/index.js
@@ -38,8 +38,11 @@ import {location} from 'vfile-location'
  */
 export function eventsToAcorn(events, options) {
   const {prefix = '', suffix = ''} = options
+  const acornOptions = /** @type {AcornOptions} */ (options.acornOptions)
   /** @type {Array.<Comment>} */
-  const comments = []
+  const comments = Array.isArray(acornOptions.onComment)
+    ? acornOptions.onComment
+    : []
   const acornConfig = Object.assign({}, options.acornOptions, {
     onComment: comments,
     preserveParens: true

--- a/packages/micromark-util-events-to-acorn/dev/index.js
+++ b/packages/micromark-util-events-to-acorn/dev/index.js
@@ -38,12 +38,10 @@ import {location} from 'vfile-location'
  */
 export function eventsToAcorn(events, options) {
   const {prefix = '', suffix = ''} = options
-  const acornOptions = /** @type {AcornOptions} */ (options.acornOptions)
+  const acornOptions = options.acornOptions
   /** @type {Array.<Comment>} */
-  const comments = Array.isArray(acornOptions.onComment)
-    ? acornOptions.onComment
-    : []
-  const acornConfig = Object.assign({}, options.acornOptions, {
+  const comments = []
+  const acornConfig = Object.assign({}, acornOptions, {
     onComment: comments,
     preserveParens: true
   })
@@ -178,6 +176,10 @@ export function eventsToAcorn(events, options) {
       // @ts-expect-error: acorn has positions.
       esnode.range = [esnode.start, esnode.end]
     })
+
+    if (acornOptions && Array.isArray(acornOptions.onComment)) {
+      acornOptions.onComment.push(...comments)
+    }
   }
 
   // @ts-expect-error: It’s a program now.

--- a/test/index.js
+++ b/test/index.js
@@ -131,18 +131,51 @@ test('micromark-extension-mdx-expression', (t) => {
               start: 3,
               end: 4,
               name: 'b',
-              loc: {start: {line: 1, column: 3}, end: {line: 1, column: 4}},
+              loc: {
+                start: {
+                  line: 1,
+                  column: 3,
+                  offset: 3
+                },
+                end: {
+                  line: 1,
+                  column: 4,
+                  offset: 4
+                }
+              },
               range: [3, 4]
             },
             start: 3,
             end: 4,
-            loc: {start: {line: 1, column: 3}, end: {line: 1, column: 4}},
+            loc: {
+              start: {
+                line: 1,
+                column: 3,
+                offset: 3
+              },
+              end: {
+                line: 1,
+                column: 4,
+                offset: 4
+              }
+            },
             range: [3, 4]
           }
         ],
         sourceType: 'module',
         comments: [],
-        loc: {start: {line: 1, column: 3}, end: {line: 1, column: 4}},
+        loc: {
+          start: {
+            line: 1,
+            column: 3,
+            offset: 3
+          },
+          end: {
+            line: 1,
+            column: 4,
+            offset: 4
+          }
+        },
         range: [3, 4]
       },
       '`addResult` should add an expression'
@@ -184,7 +217,18 @@ test('micromark-extension-mdx-expression', (t) => {
         body: [],
         sourceType: 'module',
         comments: [],
-        loc: {start: {line: 1, column: 3}, end: {line: 1, column: 3}},
+        loc: {
+          start: {
+            line: 1,
+            column: 3,
+            offset: 3
+          },
+          end: {
+            line: 1,
+            column: 3,
+            offset: 3
+          }
+        },
         range: [3, 3]
       },
       '`estree` should be an empty program for an empty expression'
@@ -333,7 +377,18 @@ test('micromark-extension-mdx-expression', (t) => {
       value: 'b',
       start: 3,
       end: 8,
-      loc: {start: {line: 1, column: 3}, end: {line: 1, column: 8}},
+      loc: {
+        start: {
+          line: 1,
+          column: 3,
+          offset: 3
+        },
+        end: {
+          line: 1,
+          column: 8,
+          offset: 8
+        }
+      },
       range: [3, 8]
     },
     {
@@ -341,7 +396,18 @@ test('micromark-extension-mdx-expression', (t) => {
       value: ' c',
       start: 9,
       end: 13,
-      loc: {start: {line: 1, column: 9}, end: {line: 1, column: 13}},
+      loc: {
+        start: {
+          line: 1,
+          column: 9,
+          offset: 9
+        },
+        end: {
+          line: 1,
+          column: 13,
+          offset: 13
+        }
+      },
       range: [9, 13]
     }
   ])
@@ -363,7 +429,18 @@ test('micromark-extension-mdx-expression', (t) => {
             value: 'b',
             start: 3,
             end: 8,
-            loc: {start: {line: 1, column: 3}, end: {line: 1, column: 8}},
+            loc: {
+              start: {
+                line: 1,
+                column: 3,
+                offset: 3
+              },
+              end: {
+                line: 1,
+                column: 8,
+                offset: 8
+              }
+            },
             range: [3, 8]
           },
           {
@@ -371,11 +448,33 @@ test('micromark-extension-mdx-expression', (t) => {
             value: ' c',
             start: 9,
             end: 13,
-            loc: {start: {line: 1, column: 9}, end: {line: 1, column: 13}},
+            loc: {
+              start: {
+                line: 1,
+                column: 9,
+                offset: 9
+              },
+              end: {
+                line: 1,
+                column: 13,
+                offset: 13
+              }
+            },
             range: [9, 13]
           }
         ],
-        loc: {start: {line: 1, column: 3}, end: {line: 2, column: 0}},
+        loc: {
+          start: {
+            line: 1,
+            column: 3,
+            offset: 3
+          },
+          end: {
+            line: 2,
+            column: 0,
+            offset: 14
+          }
+        },
         range: [3, 14]
       },
       '`estree` should have comments'
@@ -462,11 +561,13 @@ test('micromark-extension-mdx-expression', (t) => {
         loc: {
           start: {
             line: 1,
-            column: 3
+            column: 3,
+            offset: 3
           },
           end: {
             line: 1,
-            column: 4
+            column: 4,
+            offset: 4
           }
         },
         range: [3, 4]
@@ -488,11 +589,13 @@ test('micromark-extension-mdx-expression', (t) => {
         loc: {
           start: {
             line: 1,
-            column: 4
+            column: 4,
+            offset: 4
           },
           end: {
             line: 1,
-            column: 5
+            column: 5,
+            offset: 5
           }
         },
         range: [4, 5]
@@ -514,11 +617,13 @@ test('micromark-extension-mdx-expression', (t) => {
         loc: {
           start: {
             line: 1,
-            column: 5
+            column: 5,
+            offset: 5
           },
           end: {
             line: 1,
-            column: 6
+            column: 6,
+            offset: 6
           }
         },
         range: [5, 6]

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 /**
+ * @typedef {import('acorn').Comment} Comment
  * @typedef {import('micromark-util-types').HtmlExtension} HtmlExtension
  * @typedef {import('micromark-util-types').Handle} Handle
  */
@@ -296,9 +297,21 @@ test('micromark-extension-mdx-expression', (t) => {
     'should support an expression followed by a line comment and a line ending'
   )
 
+  /** @type {Array.<Comment>} */
+  const comments = []
+
   t.equal(
     micromark('a {/*b*/ // c\n} d', {
-      extensions: [syntax({acorn, addResult: true})],
+      extensions: [
+        syntax({
+          acorn,
+          acornOptions: {
+            ecmaVersion: 6,
+            onComment: comments
+          },
+          addResult: true
+        })
+      ],
       htmlExtensions: [
         {
           enter: {
@@ -312,6 +325,25 @@ test('micromark-extension-mdx-expression', (t) => {
     '<p>a  d</p>',
     'should support `addResult` for comments'
   )
+
+  t.deepEqual(comments, [
+    {
+      type: 'Block',
+      value: 'b',
+      start: 3,
+      end: 8,
+      loc: {start: {line: 1, column: 3}, end: {line: 1, column: 8}},
+      range: [3, 8]
+    },
+    {
+      type: 'Line',
+      value: ' c',
+      start: 9,
+      end: 13,
+      loc: {start: {line: 1, column: 9}, end: {line: 1, column: 13}},
+      range: [9, 13]
+    }
+  ])
 
   /** @type {Handle} */
   function checkResultComments(token) {


### PR DESCRIPTION
close #3

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

As title

<!--do not edit: pr-->
