### PR TITLE
fix: filter out prefix and suffix for onToken

### DIFF
--- a/packages/micromark-util-events-to-acorn/dev/index.js
+++ b/packages/micromark-util-events-to-acorn/dev/index.js
@@ -8,7 +8,7 @@
  * @typedef {import('estree').Program} Program
  * @typedef {import('estree-util-visit').Node} EstreeNode
  *
- * @typedef {{parse: import('acorn').parse, parseExpressionAt: import('acorn').parseExpressionAt}} Acorn
+ * @typedef {{parse: import('acorn').parse, parseExpressionAt: import('acorn').parseExpressionAt, acorn: typeof import('acorn')}} Acorn
  * @typedef {Error & {raisedAt: number, pos: number, loc: {line: number, column: number}}} AcornError
  *
  * @typedef Options
@@ -183,8 +183,21 @@ export function eventsToAcorn(events, options) {
       }
     }
 
+    const tt = options.acorn.acorn.tokTypes
+
     for (const token of tokens) {
       fixPosition(token)
+
+      // Prefix and suffix should be ignored
+      if (
+        token.start === token.end &&
+        (token.type === tt.braceL ||
+          token.type === tt.braceR ||
+          token.type === tt.parenL ||
+          token.type === tt.parenR)
+      ) {
+        continue
+      }
 
       if (Array.isArray(onToken)) {
         onToken.push(token)

--- a/packages/micromark-util-events-to-acorn/dev/index.js
+++ b/packages/micromark-util-events-to-acorn/dev/index.js
@@ -8,7 +8,7 @@
  * @typedef {import('estree').Program} Program
  * @typedef {import('estree-util-visit').Node} EstreeNode
  *
- * @typedef {{parse: import('acorn').parse, parseExpressionAt: import('acorn').parseExpressionAt, acorn: typeof import('acorn')}} Acorn
+ * @typedef {{parse: import('acorn').parse, parseExpressionAt: import('acorn').parseExpressionAt}} Acorn
  * @typedef {Error & {raisedAt: number, pos: number, loc: {line: number, column: number}}} AcornError
  *
  * @typedef Options
@@ -183,18 +183,14 @@ export function eventsToAcorn(events, options) {
       }
     }
 
-    const tt = options.acorn.acorn.tokTypes
-
     for (const token of tokens) {
       fixPosition(token)
 
       // Prefix and suffix should be ignored
       if (
         token.start === token.end &&
-        (token.type === tt.braceL ||
-          token.type === tt.braceR ||
-          token.type === tt.parenL ||
-          token.type === tt.parenR)
+        ((prefix && prefix.includes(token.type.label)) ||
+          (suffix && suffix.includes(token.type.label)))
       ) {
         continue
       }

--- a/test/index.js
+++ b/test/index.js
@@ -592,6 +592,50 @@ test('micromark-extension-mdx-expression', (t) => {
 
   t.deepEqual(tokens, tokens2, 'should support `onToken` (function-form, 2)')
 
+  /** @type {Array<Token>} */
+  const tokens3 = []
+
+  t.equal(
+    micromark('...{}', {
+      extensions: [
+        syntax({
+          acorn,
+          acornOptions: {ecmaVersion: 6, onToken: tokens3},
+          spread: true
+        })
+      ],
+      htmlExtensions: [html]
+    }),
+    '<p>...</p>',
+    'should filter out `prefix` and `suffix` for `onToken`'
+  )
+
+  t.equal(
+    JSON.stringify(tokens3),
+    JSON.stringify([
+      {
+        type: {
+          label: 'eof',
+          beforeExpr: false,
+          startsExpr: false,
+          isLoop: false,
+          isAssign: false,
+          prefix: false,
+          postfix: false,
+          binop: null,
+          updateContext: null
+        },
+        start: 4,
+        end: 4,
+        loc: {
+          start: {line: 1, column: 4, offset: 4},
+          end: {line: 1, column: 4, offset: 4}
+        },
+        range: [4, 4]
+      }
+    ])
+  )
+
   t.equal(
     micromark('a {b.c} d', {
       extensions: [syntax({acorn})],


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

close #6

<!--do not edit: pr-->
