### PR TITLE
Flow expressions incorrectly strip indentation from continuation lines

### DIFF
--- a/packages/micromark-factory-mdx-expression/dev/index.js
+++ b/packages/micromark-factory-mdx-expression/dev/index.js
@@ -97,6 +97,8 @@ export function factoryMdxExpression(
   let pointStart
   /** @type {Error} */
   let lastCrash
+  /** @type {number | undefined} */
+  let lineIndent
 
   return start
 
@@ -112,6 +114,24 @@ export function factoryMdxExpression(
    */
   function start(code) {
     assert(code === codes.leftCurlyBrace, 'expected `{`')
+
+    // When the expression starts at a line start, continuation lines are
+    // indented as far as the opening brace at most.
+    // When it starts after other things (such as in attributes or text),
+    // we cannot know the indent, see `eolAfter`.
+    const tail = self.events.at(-1)
+
+    if (!tail || tail[1].type === types.lineEnding) {
+      // { is the first thing on the line, no indent to strip
+      lineIndent = 0
+    } else if (tail[0] === 'exit' && tail[1].type === types.linePrefix) {
+      // { follows leading whitespace, strip exactly that much
+      lineIndent = tail[1].end.column - tail[1].start.column
+    } else {
+      // { is mid-line (attribute, text, etc), fall back to indentSize
+      lineIndent = undefined
+    }
+
     effects.enter(type)
     effects.enter(markerType)
     effects.consume(code)
@@ -254,6 +274,12 @@ export function factoryMdxExpression(
       throw error
     }
 
+    // When the expression started at a line start, eat as much indent as
+    // there was before the opening brace: that indent is decoration, the
+    // rest is content (such as whitespace in a template literal).
+    //
+    // When the expression started after other things, we cannot know the
+    // indent, so we eat up to `indentSize`.
     // Note: `markdown-rs` uses `4`, but we use `2`.
     //
     // Idea: investigate if we’d need to use more complex stripping.
@@ -269,12 +295,10 @@ export function factoryMdxExpression(
     // here we split it into `>␠|␠␠|␠␠␠d` (prefix, this indent here,
     // expression data).
     if (markdownSpace(code)) {
-      return factorySpace(
-        effects,
-        before,
-        types.linePrefix,
-        indentSize + 1
-      )(code)
+      const max = lineIndent === undefined ? indentSize : lineIndent
+
+      if (max === 0) return before(code)
+      return factorySpace(effects, before, types.linePrefix, max + 1)(code)
     }
 
     return before(code)

--- a/test/index.js
+++ b/test/index.js
@@ -1760,6 +1760,42 @@ test('flow (gnostic)', async function (t) {
     }
   )
 
+  await t.test(
+    'should keep the correct number of spaces at the root',
+    function () {
+      /** @type {Program | undefined} */
+      let program
+
+      micromark('{`\nbravo\n  charlie\n    delta\n`}', {
+        extensions: [
+          createExtensionFromFactoryOptions(
+            acorn,
+            {ecmaVersion: 'latest'},
+            true
+          )
+        ],
+        htmlExtensions: [{enter: {expression}}]
+      })
+
+      assert(program)
+      const statement = program.body[0]
+      assert(statement.type === 'ExpressionStatement')
+      assert(statement.expression.type === 'TemplateLiteral')
+      const quasi = statement.expression.quasis[0]
+      assert(quasi)
+      const value = quasi.value.cooked
+      assert.equal(value, '\nbravo\n  charlie\n    delta\n')
+
+      /**
+       * @this {CompileContext}
+       * @type {Handle}
+       */
+      function expression(token) {
+        program = token.estree
+      }
+    }
+  )
+
   await t.test('should support `\\0` and `\\r` in expressions', function () {
     /** @type {Program | undefined} */
     let program

--- a/test/index.js
+++ b/test/index.js
@@ -1796,6 +1796,19 @@ test('flow (gnostic)', async function (t) {
     }
   )
 
+  await t.test(
+    'should support a multiline non-string expression at the root',
+    async function () {
+      assert.equal(
+        micromark('{\n  1 + 1\n}', {
+          extensions: [mdxExpression({acorn})],
+          htmlExtensions: [html]
+        }),
+        ''
+      )
+    }
+  )
+
   await t.test('should support `\\0` and `\\r` in expressions', function () {
     /** @type {Program | undefined} */
     let program

--- a/test/index.js
+++ b/test/index.js
@@ -1748,7 +1748,7 @@ test('flow (gnostic)', async function (t) {
       const quasi = statement.expression.quasis[0]
       assert(quasi)
       const value = quasi.value.cooked
-      assert.equal(value, '\nalpha\nbravo\ncharlie\n delta\n')
+      assert.equal(value, '\nalpha\n bravo\n  charlie\n   delta\n')
 
       /**
        * @this {CompileContext}


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amicromark&type=issues and https://github.com/orgs/micromark/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Flow expressions with no leading indent have their continuation-line whitespace stripped. Template literals lose their internal indentation:

  ```mdx
  {`
  def greet(name):
      print(f"Hello, {name}")
  `}
  ```

The 4-space indent is silently reduced to 2 spaces. Related: mdx-js/mdx#2533.
  
#### Cause

`eolAfter()` is called after each line ending inside an expression. Its job is to consume leading whitespace on the next line before passing control back to the expression parser. It always consumes up to `indentSize` (2) spaces.

This is correct when the expression is inside a container like a blockquote or list - those leading spaces are structural indentation that belongs to the container, not to the expression content.

But when the opening `{` sits at column 0 with no leading indent, there is no structural indentation. Any spaces on continuation lines are content, such as the indentation inside a template literal. Consuming them corrupts the value.

#### Solution

In `start()`, before the expression is parsed, record how much indent preceded the opening `{` as `lineIndent`:
- `0` if `{` is the first thing on the line
- the number of leading spaces if `{` was preceded by a `linePrefix` token
- `undefined` if `{` is mid-line (attribute, text, etc) - meaning we cannot know the structural indent

In `eolAfter()`, use `lineIndent` to cap how much whitespace is consumed:
- if `lineIndent` is `0`, skip consumption entirely - all spaces are content
- if `lineIndent` is a known width, consume at most that many spaces
- if `lineIndent` is `undefined`, fall back to the original `indentSize` limit


<!--do not edit: pr-->
